### PR TITLE
feat(projects): add SEO landing pages

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -20,6 +20,16 @@ for (const file of readdirSync('./src/content/blog')) {
   }
 }
 
+const projectLastmod = {};
+for (const file of readdirSync('./src/content/projects')) {
+  if (!file.endsWith('.md') && !file.endsWith('.mdx')) continue;
+  const source = readFileSync(`./src/content/projects/${file}`, 'utf8');
+  const updated = source.match(/^updatedDate:\s*['"]?([^'"\s]+)/m)?.[1];
+  if (updated) {
+    projectLastmod[`/projects/${file.replace(/\.mdx?$/, '').toLowerCase()}/`] = new Date(updated);
+  }
+}
+
 export default defineConfig({
   site: 'https://jamesbrink.online',
   // Removed near-duplicate post; keep its URL alive for anyone who bookmarked it.
@@ -34,7 +44,8 @@ export default defineConfig({
     mdx(),
     sitemap({
       serialize(item) {
-        const lastmod = postLastmod[new URL(item.url).pathname];
+        const pathname = new URL(item.url).pathname;
+        const lastmod = postLastmod[pathname] || projectLastmod[pathname];
         return lastmod ? { ...item, lastmod: lastmod.toISOString() } : item;
       },
     }),

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: 'http://localhost:4321',
+    baseURL: 'http://127.0.0.1:4321',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
@@ -31,42 +31,20 @@ export default defineConfig({
   projects: [
     {
       name: 'chromium',
-      use: {
-        ...devices['Desktop Chrome'],
-        launchOptions: {
-          executablePath: '/usr/bin/chromium',
-          args: [
-            '--no-sandbox',
-            '--disable-setuid-sandbox',
-            '--disable-dev-shm-usage',
-            '--disable-gpu',
-          ],
-        },
-      },
+      use: { ...devices['Desktop Chrome'] },
     },
 
     /* Test against mobile viewports. */
     {
       name: 'Mobile Chrome',
-      use: {
-        ...devices['Pixel 5'],
-        launchOptions: {
-          executablePath: '/usr/bin/chromium',
-          args: [
-            '--no-sandbox',
-            '--disable-setuid-sandbox',
-            '--disable-dev-shm-usage',
-            '--disable-gpu',
-          ],
-        },
-      },
+      use: { ...devices['Pixel 5'] },
     },
   ],
 
   /* Run your local dev server before starting the tests */
   webServer: {
-    command: 'docker compose up',
-    url: 'http://localhost:4321',
+    command: 'bun run dev -- --host 0.0.0.0',
+    url: 'http://127.0.0.1:4321',
     reuseExistingServer: !process.env.CI,
     timeout: 120 * 1000,
   },

--- a/src/components/ProjectCard.astro
+++ b/src/components/ProjectCard.astro
@@ -1,29 +1,29 @@
 ---
 import clsx from 'clsx';
 
-export interface Project {
+export interface ProjectSummary {
+  slug?: string;
   name: string;
   tagline: string;
   description: string;
-  href: string;
+  repository: string;
   techStack: string[];
   featured?: boolean;
   stars?: number;
   forks?: number;
+  latestRelease?: string;
+  latestReleaseUrl?: string;
 }
 
 interface Props {
-  project: Project;
+  project: ProjectSummary;
   featured?: boolean;
 }
 
 const { project, featured = false } = Astro.props;
 ---
 
-<a
-  href={project.href}
-  target="_blank"
-  rel="noopener noreferrer"
+<article
   class={clsx(
     'group relative flex flex-col rounded-2xl border p-6 transition',
     'border-hairline hover:border-edge',
@@ -32,13 +32,25 @@ const { project, featured = false } = Astro.props;
 >
   <div class="flex items-start justify-between gap-4">
     <div class="flex-1">
-      <h3
-        class={clsx(
-          'font-semibold text-heading group-hover:text-link',
-          featured ? 'text-lg' : 'text-base'
-        )}
-      >
-        {project.name}
+      <h3 class={clsx('font-semibold text-heading', featured ? 'text-lg' : 'text-base')}>
+        {
+          project.slug ? (
+            <a href={`/projects/${project.slug}/`} class="group-hover:text-link transition">
+              <span class="absolute inset-0 rounded-2xl" />
+              {project.name}
+            </a>
+          ) : (
+            <a
+              href={project.repository}
+              target="_blank"
+              rel="noopener noreferrer"
+              class="group-hover:text-link transition"
+            >
+              <span class="absolute inset-0 rounded-2xl" />
+              {project.name}
+            </a>
+          )
+        }
       </h3>
       <p class="text-accent mt-1 text-sm font-medium">
         {project.tagline}
@@ -86,23 +98,24 @@ const { project, featured = false } = Astro.props;
     }
   </div>
 
-  <div class="text-subtle group-hover:text-link mt-4 flex items-center gap-2 text-sm">
-    <svg class="h-4 w-4" fill="currentColor" viewBox="0 0 24 24">
-      <path
-        fill-rule="evenodd"
-        clip-rule="evenodd"
-        d="M12 2C6.475 2 2 6.588 2 12.253c0 4.537 2.862 8.369 6.838 9.727.5.09.687-.218.687-.487 0-.243-.013-1.05-.013-1.91C7 20.059 6.35 18.957 6.15 18.38c-.113-.295-.6-1.205-1.025-1.448-.35-.192-.85-.667-.013-.68.788-.012 1.35.744 1.538 1.051.9 1.551 2.338 1.116 2.912.846.088-.666.35-1.115.638-1.371-2.225-.256-4.55-1.14-4.55-5.062 0-1.115.387-2.038 1.025-2.756-.1-.256-.45-1.307.1-2.717 0 0 .837-.269 2.75 1.051.8-.23 1.65-.346 2.5-.346.85 0 1.7.115 2.5.346 1.912-1.333 2.75-1.05 2.75-1.05.55 1.409.2 2.46.1 2.716.637.718 1.025 1.628 1.025 2.756 0 3.934-2.337 4.806-4.562 5.062.362.32.675.936.675 1.897 0 1.371-.013 2.473-.013 2.82 0 .268.188.589.688.486a10.039 10.039 0 0 0 4.932-3.74A10.447 10.447 0 0 0 22 12.253C22 6.588 17.525 2 12 2Z"
-      ></path>
-    </svg>
-    <span>View on GitHub</span>
-    <svg
-      class="h-4 w-4 transition group-hover:translate-x-1"
-      fill="none"
-      viewBox="0 0 24 24"
-      stroke="currentColor"
-      stroke-width="2"
+  <div
+    class="text-subtle group-hover:text-link relative z-10 mt-4 flex items-center justify-between gap-3 text-sm"
+  >
+    <span>{project.slug ? 'Explore project' : 'View on GitHub'}</span>
+    <a
+      href={project.repository}
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-label={`View ${project.name} on GitHub`}
+      class="border-hairline hover:border-edge hover:text-link rounded-full border p-2 transition"
     >
-      <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7"></path>
-    </svg>
+      <svg class="h-4 w-4" fill="currentColor" viewBox="0 0 24 24">
+        <path
+          fill-rule="evenodd"
+          clip-rule="evenodd"
+          d="M12 2C6.475 2 2 6.588 2 12.253c0 4.537 2.862 8.369 6.838 9.727.5.09.687-.218.687-.487 0-.243-.013-1.05-.013-1.91C7 20.059 6.35 18.957 6.15 18.38c-.113-.295-.6-1.205-1.025-1.448-.35-.192-.85-.667-.013-.68.788-.012 1.35.744 1.538 1.051.9 1.551 2.338 1.116 2.912.846.088-.666.35-1.115.638-1.371-2.225-.256-4.55-1.14-4.55-5.062 0-1.115.387-2.038 1.025-2.756-.1-.256-.45-1.307.1-2.717 0 0 .837-.269 2.75 1.051.8-.23 1.65-.346 2.5-.346.85 0 1.7.115 2.5.346 1.912-1.333 2.75-1.05 2.75-1.05.55 1.409.2 2.46.1 2.716.637.718 1.025 1.628 1.025 2.756 0 3.934-2.337 4.806-4.562 5.062.362.32.675.936.675 1.897 0 1.371-.013 2.473-.013 2.82 0 .268.188.589.688.486a10.039 10.039 0 0 0 4.932-3.74A10.447 10.447 0 0 0 22 12.253C22 6.588 17.525 2 12 2Z"
+        ></path>
+      </svg>
+    </a>
   </div>
-</a>
+</article>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -16,4 +16,40 @@ const blog = defineCollection({
   }),
 });
 
-export const collections = { blog };
+const projectLink = z.object({
+  label: z.string(),
+  url: z.string().url(),
+});
+
+const projects = defineCollection({
+  loader: glob({ pattern: '**/*.{md,mdx}', base: './src/content/projects' }),
+  schema: z.object({
+    title: z.string(),
+    tagline: z.string(),
+    description: z.string(),
+    repository: z.string().url(),
+    website: z.string().url().optional(),
+    docs: z.string().url().optional(),
+    techStack: z.array(z.string()).min(1),
+    keywords: z.array(z.string()).min(1),
+    language: z.string(),
+    license: z.string(),
+    updatedDate: z.coerce.date(),
+    featuredOrder: z.number().int().positive(),
+    problem: z.object({
+      body: z.string(),
+      pains: z.array(z.string()).min(2),
+    }),
+    features: z.array(z.object({ title: z.string(), description: z.string() })).min(4),
+    quickStarts: z.array(z.object({ label: z.string(), code: z.string() })).min(1),
+    integrations: z.array(z.string()).min(1),
+    architecture: z.array(z.object({ title: z.string(), description: z.string() })).min(3),
+    closing: z.object({
+      title: z.string(),
+      body: z.string(),
+    }),
+    links: z.array(projectLink).min(1),
+  }),
+});
+
+export const collections = { blog, projects };

--- a/src/content/projects/claudette.mdx
+++ b/src/content/projects/claudette.mdx
@@ -1,0 +1,62 @@
+---
+title: Claudette
+tagline: Claude Code's missing better half.
+description: Run parallel coding agents in isolated worktrees, manage sessions and pull requests, and connect remote workspaces from a native Tauri desktop control center.
+repository: https://github.com/utensils/claudette
+website: https://utensils.github.io/claudette/
+docs: https://utensils.github.io/claudette/
+techStack: [Rust, Tauri, React, TypeScript]
+keywords: [Claude Code GUI, Claude Code worktree manager, parallel coding agents, Claudette app]
+language: Rust
+license: MIT
+updatedDate: 2026-07-17
+featuredOrder: 5
+problem:
+  body: Running one coding agent is easy. Running six means terminal roulette, mystery branches, and at least one agent quietly doing something cursed. Claudette turns that mess into a control surface.
+  pains:
+    - Agents trampling the same checkout
+    - No useful view of parallel session state
+    - Pull requests and CI scattered across browser tabs
+    - Remote machines feeling like a completely different workflow
+features:
+  - title: Isolated worktrees
+    description: Give every agent its own branch and checkout so parallelism stops meaning merge-conflict roulette.
+  - title: Session control
+    description: Start, inspect, pause, fork, and resume agent conversations from one native interface.
+  - title: Plan and question handling
+    description: Approve plans and answer agent questions without hunting for the terminal that asked.
+  - title: Pull request workflow
+    description: Track reviews, checks, and merges through extensible SCM-provider plugins.
+  - title: Remote workspaces
+    description: Pair with another machine over encrypted WebSocket and manage its repositories as local surfaces.
+  - title: CLI and agent skill
+    description: Script Claudette itself or let a coordinator agent fan work across isolated workspaces.
+quickStarts:
+  - label: Development
+    code: |-
+      git clone https://github.com/utensils/claudette
+      cd claudette
+      ./scripts/dev.sh --new
+  - label: Build
+    code: cargo tauri build
+integrations: [Claude Code, Codex, Ollama, OpenAI, GitHub, GitLab, MCP, Nix]
+architecture:
+  - title: Native shell
+    description: Tauri provides a cross-platform desktop surface around Rust orchestration services.
+  - title: Workspace isolation
+    description: Repositories, worktrees, branches, and agents stay explicitly connected.
+  - title: Provider layer
+    description: Agent, SCM, environment, and MCP providers remain replaceable instead of welded together.
+  - title: Local or remote control
+    description: The same UI drives this machine, paired hosts, or a standalone headless server.
+closing:
+  title: Stop tabbing through terminal purgatory
+  body: Give every agent a lane and keep the entire coding circus visible.
+links:
+  - label: Read the documentation
+    url: https://utensils.github.io/claudette/
+  - label: View on GitHub
+    url: https://github.com/utensils/claudette
+---
+
+Claudette is a native cockpit for the moment one coding agent becomes an accidental engineering department.

--- a/src/content/projects/comfyui-nix.mdx
+++ b/src/content/projects/comfyui-nix.mdx
@@ -1,0 +1,62 @@
+---
+title: ComfyUI Nix
+tagline: Reproducible image generation, even when Python has other plans.
+description: Run ComfyUI through a pure Nix flake with curated custom nodes and practical GPU support for Apple Silicon, NVIDIA CUDA, AMD ROCm, and Intel XPU.
+repository: https://github.com/utensils/comfyui-nix
+website: https://flakehub.com/flake/utensils/comfyui
+techStack: [Nix, Python, ComfyUI, PyTorch]
+keywords: [ComfyUI Nix flake, reproducible ComfyUI, ComfyUI CUDA NixOS, Apple Silicon ComfyUI]
+language: Nix
+license: MIT
+updatedDate: 2026-07-20
+featuredOrder: 4
+problem:
+  body: ComfyUI is powerful. Its Python environment, binary wheels, custom nodes, and GPU matrix are a hostage negotiation. This flake makes the negotiation reproducible.
+  pains:
+    - Python environments that decay between launches
+    - Custom nodes pulling incompatible dependencies
+    - CUDA builds consuming hours and absurd amounts of memory
+    - Different setup rituals for every GPU vendor
+features:
+  - title: Pure Nix environment
+    description: Pin ComfyUI, Python, dependencies, and curated nodes in one reproducible input graph.
+  - title: Apple Silicon
+    description: Run on macOS with the platform's native acceleration path and normal data locations.
+  - title: NVIDIA CUDA
+    description: Use pre-built PyTorch wheels from Pascal through Blackwell instead of compiling the universe.
+  - title: AMD ROCm
+    description: Launch the ROCm variant with bundled runtime dependencies for supported hardware.
+  - title: Intel XPU
+    description: Use current oneAPI and SYCL wheels for supported Arc and Core Ultra GPUs.
+  - title: Curated custom nodes
+    description: Enable a maintained collection of popular nodes without dependency roulette.
+quickStarts:
+  - label: Default
+    code: nix run github:utensils/comfyui-nix -- --open
+  - label: NVIDIA CUDA
+    code: nix run github:utensils/comfyui-nix#cuda
+  - label: AMD or Intel
+    code: |-
+      nix run github:utensils/comfyui-nix#rocm
+      nix run github:utensils/comfyui-nix#xpu
+integrations: [ComfyUI, Nix, FlakeHub, Cachix, CUDA, ROCm, Intel XPU, Apple Silicon]
+architecture:
+  - title: Pinned flake
+    description: Nix locks the application, Python environment, nodes, and platform variants.
+  - title: Hardware target
+    description: Select the default, CUDA, ROCm, or XPU output for the machine in front of you.
+  - title: Binary runtime
+    description: Cached packages and upstream wheels avoid gratuitous source builds.
+  - title: ComfyUI workspace
+    description: Models, outputs, and configuration stay in predictable persistent locations.
+closing:
+  title: Generate images, not dependency conflicts
+  body: Pick the hardware output, run the flake, and let Nix remember what worked.
+links:
+  - label: Open on FlakeHub
+    url: https://flakehub.com/flake/utensils/comfyui
+  - label: View on GitHub
+    url: https://github.com/utensils/comfyui-nix
+---
+
+ComfyUI Nix keeps the creative workflow weird and the dependency graph boring.

--- a/src/content/projects/envisaged.mdx
+++ b/src/content/projects/envisaged.mdx
@@ -1,0 +1,58 @@
+---
+title: Envisaged
+tagline: Turn repository archaeology into something worth watching.
+description: Render Git history, multi-repository comparisons, and Linux system timelines as polished Gource videos with a Nix-first CLI and web interface.
+repository: https://github.com/utensils/Envisaged
+techStack: [Python, Nix, Gource, FFmpeg]
+keywords:
+  [Git history visualization, Gource video generator, repository visualization, system log timeline]
+language: Python
+license: MIT
+updatedDate: 2026-03-28
+featuredOrder: 2
+problem:
+  body: Git logs are technically complete and spiritually unreadable. Envisaged turns years of commits—or a machine's journal—into a timeline humans can actually absorb.
+  pains:
+    - Gource and FFmpeg commands assembled by ritual sacrifice
+    - Multi-repository timelines that drift out of sync
+    - 4K renders melting the laptop you still need for work
+    - System logs that explain nothing at presentation speed
+features:
+  - title: Repository history
+    description: Render a single Git repository with titles, legends, templates, and sane defaults.
+  - title: Multi-repo comparison
+    description: Synchronize several repositories into one comparable visual timeline.
+  - title: System timelines
+    description: Convert journal, kernel, and authentication logs into service-focused animations.
+  - title: Template families
+    description: Choose core, compare, split, relation, and themed layouts without rebuilding commands.
+  - title: Web interface
+    description: Queue renders from a mobile-first UI when the terminal has had enough attention.
+  - title: Reproducible builds
+    description: Run the CLI, web app, and container builds through a Nix flake.
+quickStarts:
+  - label: Render this repository
+    code: nix run github:utensils/Envisaged -- -o history.mp4 -t "Repo History" .
+  - label: Local Python development
+    code: |-
+      uv sync
+      uv run envisaged --help
+integrations: [Git, Gource, FFmpeg, Nix, journalctl, GitHub Actions, Docker, systemd]
+architecture:
+  - title: Source timeline
+    description: Git repositories or structured system logs become timestamped events.
+  - title: Envisaged templates
+    description: Python normalizes events, layout, timing, legends, and rendering options.
+  - title: Gource and FFmpeg
+    description: The visualizer draws the history while FFmpeg handles production output.
+  - title: Shareable video
+    description: Deliver an MP4 instead of asking everyone to appreciate your git log command.
+closing:
+  title: Make the history visible
+  body: Your repository has a story. It deserves better than monospace archaeology.
+links:
+  - label: View on GitHub
+    url: https://github.com/utensils/Envisaged
+---
+
+Envisaged packages the ugly rendering pipeline so the result—not the command—gets the attention.

--- a/src/content/projects/mcp-nixos.mdx
+++ b/src/content/projects/mcp-nixos.mdx
@@ -1,0 +1,65 @@
+---
+title: MCP NixOS
+tagline: Because your AI shouldn't hallucinate package names.
+description: Give Claude, Codex, and other AI assistants accurate NixOS packages, options, Home Manager modules, and official documentation through MCP.
+repository: https://github.com/utensils/mcp-nixos
+website: https://mcp-nixos.io/
+docs: https://mcp-nixos.io/
+techStack: [Python, MCP, NixOS, FastMCP]
+keywords: [NixOS MCP server, Model Context Protocol, Nix package search, Home Manager options]
+language: Python
+license: MIT
+updatedDate: 2026-07-22
+featuredOrder: 1
+problem:
+  body: AI assistants are great right up until they confidently invent a package, option, or module that has never existed. MCP NixOS replaces the vibes with live, authoritative Nix data.
+  pains:
+    - Hallucinated package names and versions
+    - Outdated or incorrect NixOS options
+    - Missing Home Manager and nix-darwin modules
+    - Broken links to docs and manual pages
+features:
+  - title: NixOS packages
+    description: Search packages, inspect versions, and retrieve metadata across current channels.
+  - title: NixOS options
+    description: Query types, defaults, declarations, and full option context.
+  - title: Home Manager
+    description: Browse user-level modules and release-specific configuration options.
+  - title: nix-darwin
+    description: Find the macOS options your future self will otherwise swear do not exist.
+  - title: Nixvim and NVF
+    description: Search editor module options without spelunking through generated manuals.
+  - title: FlakeHub and Noogle
+    description: Discover flakes and search Nix functions from the same MCP surface.
+  - title: Official documentation
+    description: Pull relevant NixOS Wiki and nix.dev material into the answer.
+  - title: One query interface
+    description: Use one unified tool instead of teaching every agent a pile of bespoke APIs.
+quickStarts:
+  - label: uvx
+    code: uvx mcp-nixos
+  - label: Nix
+    code: nix run github:utensils/mcp-nixos --
+  - label: Docker
+    code: docker run --rm -i ghcr.io/utensils/mcp-nixos:latest
+integrations: [Claude Desktop, Claude Code, Codex, Cursor, Zed, VS Code, Goose, Windsurf]
+architecture:
+  - title: Your MCP client
+    description: Claude, Codex, an editor, or whatever else currently owns your attention.
+  - title: MCP NixOS
+    description: FastMCP exposes a focused, read-only query surface over stdio or HTTP.
+  - title: Authoritative sources
+    description: NixOS, Home Manager, nix-darwin, FlakeHub, Noogle, wiki, and docs data.
+  - title: Useful answers
+    description: Current package and option results instead of confident synthetic nonsense.
+closing:
+  title: Give your agent real Nix data
+  body: Stop fighting invented options and spend that time breaking something more interesting.
+links:
+  - label: Read the documentation
+    url: https://mcp-nixos.io/
+  - label: View on GitHub
+    url: https://github.com/utensils/mcp-nixos
+---
+
+MCP NixOS is the plumbing between AI assistants and the sprawling, fast-moving Nix ecosystem.

--- a/src/content/projects/mold.mdx
+++ b/src/content/projects/mold.mdx
@@ -1,0 +1,61 @@
+---
+title: mold
+tagline: Local image generation. No cloud, no Python, no fuss.
+description: Generate images and short video clips on your own GPU with a fast Rust CLI, web studio, desktop app, and remote rendering support for modern diffusion models.
+repository: https://github.com/utensils/mold
+website: https://utensils.io/mold/
+docs: https://utensils.io/mold/
+techStack: [Rust, Candle, CUDA, Metal]
+keywords: [local AI image generator, Rust diffusion CLI, FLUX local GPU, mold AI]
+language: Rust
+license: MIT
+updatedDate: 2026-07-21
+featuredOrder: 6
+problem:
+  body: Local diffusion usually starts with Python archaeology and ends with your GPU judging you. mold ships the runtime, downloads models, and gets out of the way.
+  pains:
+    - Python environments held together by ancient wheel metadata
+    - Model setup spread across scripts and mystery directories
+    - Cloud APIs charging rent for hardware already under your desk
+    - Local and remote GPUs behaving like separate products
+features:
+  - title: Rust-native inference
+    description: Candle runs supported diffusion pipelines without a Python runtime hiding under the floorboards.
+  - title: Modern model support
+    description: Generate with FLUX, SD 1.5, SDXL, Z-Image, and supported image-to-video models.
+  - title: CLI and terminal UI
+    description: Generate, preview, pipe, manage models, and inspect jobs without leaving the terminal.
+  - title: Mold Studio
+    description: Use the bundled web interface for creation, history, models, machines, and settings.
+  - title: Desktop and iPhone
+    description: Drive the same generation system from native desktop and mobile clients.
+  - title: Remote and cloud GPUs
+    description: Route work to remembered machines or provision RunPod capacity when the local GPU taps out.
+quickStarts:
+  - label: Install
+    code: curl -fsSL https://raw.githubusercontent.com/utensils/mold/main/install.sh | sh
+  - label: Generate
+    code: mold run "a cat riding a motorcycle through neon-lit streets"
+  - label: Nix
+    code: nix run github:utensils/mold -- run "a cat"
+integrations: [FLUX, Stable Diffusion, SDXL, Z-Image, Candle, CUDA, Metal, RunPod]
+architecture:
+  - title: Prompt and model
+    description: Resolve a local model variant and generation settings from CLI or Studio.
+  - title: Candle runtime
+    description: Rust loads the pipeline and runs inference through CUDA, Metal, or CPU backends.
+  - title: Machine routing
+    description: Keep the job local or send it to a remembered server or cloud GPU.
+  - title: Durable library
+    description: Outputs, metadata, models, and job state stay available across every client surface.
+closing:
+  title: Make the GPU earn its electricity
+  body: Install one binary, pull a model, and start generating without summoning a Python environment.
+links:
+  - label: Read the documentation
+    url: https://utensils.io/mold/
+  - label: View on GitHub
+    url: https://github.com/utensils/mold
+---
+
+mold is the shortest path from a prompt to pixels on hardware you control.

--- a/src/content/projects/nxv.mdx
+++ b/src/content/projects/nxv.mdx
@@ -1,0 +1,63 @@
+---
+title: nxv
+tagline: Find any version of any Nix package. Instantly.
+description: Search nearly a decade of nixpkgs history, find the exact package version and commit, then use it from the CLI, browser, API, or NixOS module.
+repository: https://github.com/utensils/nxv
+website: https://nxv.urandom.io/
+docs: https://utensils.io/nxv/
+techStack: [Rust, Nix, SQLite, FTS5]
+keywords: [Nix package version search, nixpkgs history, old Nix package version, nxv]
+language: Rust
+license: MIT
+updatedDate: 2026-07-21
+featuredOrder: 3
+problem:
+  body: Sometimes production needs Python 2.7, Ruby 2.6, or another fossil nobody is proud of. nxv finds the nixpkgs commit where that exact fossil still existed.
+  pains:
+    - Guessing which nixpkgs commit carried a version
+    - Searching years of Git history by hand
+    - Re-evaluating old channels for every query
+    - Treating a legacy dependency like a full-time research project
+features:
+  - title: Fast package search
+    description: Bloom filters reject misses quickly and SQLite FTS5 handles the useful work.
+  - title: Version history
+    description: See when a version appeared, changed, and disappeared from channels.
+  - title: Exact commits
+    description: Get a verified nixpkgs revision you can feed directly to Nix.
+  - title: Nested package sets
+    description: Search Python, Haskell, and other nested ecosystems without special pleading.
+  - title: CLI and browser
+    description: Query locally from the terminal or use the hosted web interface.
+  - title: API and NixOS module
+    description: Run nxv as an HTTP service with managed index updates.
+quickStarts:
+  - label: Search without installing
+    code: NXV_API_URL=https://nxv.urandom.io nix run github:utensils/nxv -- search python 2.7
+  - label: Install the CLI
+    code: curl -sSfL https://raw.githubusercontent.com/utensils/nxv/main/install.sh | sh
+  - label: Cargo
+    code: cargo install nxv
+integrations: [Nix, nixpkgs, SQLite, FTS5, HTTP API, NixOS, Docker, shell completions]
+architecture:
+  - title: Channel snapshots
+    description: Hydra-built releases provide verifiable package inventories back to 2016.
+  - title: Indexer
+    description: Historical package sets become a compact SQLite index plus Bloom filters.
+  - title: Query engine
+    description: Local or remote search resolves names, versions, and exact commits quickly.
+  - title: Reproducible result
+    description: Use the returned revision in a shell, flake, profile, or system configuration.
+closing:
+  title: Stop spelunking through nixpkgs
+  body: Ask for the version, get the commit, and return to the legacy problem you were avoiding.
+links:
+  - label: Try nxv
+    url: https://nxv.urandom.io/
+  - label: Read the documentation
+    url: https://utensils.io/nxv/
+  - label: View on GitHub
+    url: https://github.com/utensils/nxv
+---
+
+nxv turns historical nixpkgs lookup from archaeology into a normal command.

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -1,0 +1,124 @@
+import type { ProjectSummary } from '../components/ProjectCard.astro';
+
+export const otherProjects: ProjectSummary[] = [
+  {
+    name: 'Docker OpenGL',
+    tagline: 'Software rendering in containers',
+    description:
+      'Mesa 3D OpenGL software rendering for Docker containers. Enables GPU-less rendering for CI/CD pipelines, headless servers, and testing environments.',
+    repository: 'https://github.com/utensils/docker-opengl',
+    techStack: ['Docker', 'Mesa3D', 'OpenGL'],
+  },
+  {
+    name: 'Essex',
+    tagline: 'Docker project scaffolding',
+    description:
+      'A Rust-based CLI tool for generating Docker project templates. Standardizes container project structure with best practices baked in.',
+    repository: 'https://github.com/utensils/essex',
+    techStack: ['Rust', 'Docker', 'CLI'],
+  },
+  {
+    name: 'MCP Coroot',
+    tagline: 'AI-powered observability queries',
+    description:
+      'Model Context Protocol server for the Coroot observability platform. Enables AI assistants to query infrastructure metrics and application performance data.',
+    repository: 'https://github.com/jamesbrink/mcp-coroot',
+    techStack: ['TypeScript', 'MCP', 'Coroot'],
+  },
+  {
+    name: 'MCP Deadmansnitch',
+    tagline: 'AI monitoring integration',
+    description:
+      "MCP server for Dead Man's Snitch monitoring service. Allows AI assistants to check cron job health and monitoring status.",
+    repository: 'https://github.com/jamesbrink/mcp-deadmansnitch',
+    techStack: ['TypeScript', 'MCP', 'Monitoring'],
+  },
+  {
+    name: 'brinkOS',
+    tagline: 'Linux for engineers',
+    description:
+      'A custom Arch-based Linux distribution tailored for software engineers and power users, with thoughtful defaults and automated installation.',
+    repository: 'https://github.com/brinkOS/brinkOS',
+    techStack: ['Arch Linux', 'Shell', 'Systemd'],
+  },
+  {
+    name: 'Arch Linux AUR',
+    tagline: 'Package maintainer',
+    description:
+      'Maintainer of several Arch User Repository packages, contributing tested packaging and updates to the community.',
+    repository: 'https://github.com/jamesbrink/arch-aur',
+    techStack: ['Arch Linux', 'PKGBUILD', 'Shell'],
+  },
+  {
+    name: 'koban',
+    tagline: 'Invoice Ninja from the terminal',
+    description:
+      'A scriptable Rust CLI and client library for Invoice Ninja—clients, invoices, payments, and reports for humans and AI agents.',
+    repository: 'https://github.com/jamesbrink/koban',
+    techStack: ['Rust', 'CLI', 'Nix', 'REST API'],
+  },
+  {
+    name: 'claudex',
+    tagline: 'Search your Claude Code sessions',
+    description:
+      'A Rust CLI to query, search, and analyze Claude Code session history with SQLite full-text search.',
+    repository: 'https://github.com/utensils/claudex',
+    techStack: ['Rust', 'SQLite', 'FTS5', 'CLI'],
+  },
+  {
+    name: 'aethon',
+    tagline: 'Pi with a face',
+    description:
+      'A Tauri desktop shell that embeds the pi coding agent and renders its output as live, interactive UI via A2UI.',
+    repository: 'https://github.com/utensils/aethon',
+    techStack: ['Tauri', 'React', 'A2UI', 'Rust'],
+  },
+  {
+    name: 'yeet',
+    tagline: 'Brutally rude AI commit messages',
+    description:
+      'A git tool that uses a local Ollama model to write technically accurate, hilariously offensive conventional commits and push them.',
+    repository: 'https://github.com/utensils/yeet',
+    techStack: ['Bash', 'Ollama', 'Local LLM'],
+  },
+  {
+    name: 'why',
+    tagline: 'Offline error explanations',
+    description:
+      'A CLI that explains programming errors using a locally embedded LLM. No API keys, internet, or patience required.',
+    repository: 'https://github.com/jamesbrink/why',
+    techStack: ['Rust', 'LLM', 'Offline', 'Nix'],
+  },
+  {
+    name: 'burnrate',
+    tagline: 'AI spend at a glance',
+    description:
+      'A menu-bar monitor for AI subscriptions, quotas, credits, and spend without leaving the status bar.',
+    repository: 'https://github.com/jamesbrink/burnrate',
+    techStack: ['Rust', 'Tauri', 'React'],
+  },
+  {
+    name: 'strainer',
+    tagline: 'Rate limiting for AI APIs',
+    description:
+      'Process-level rate limiting and spend management for AI API consumers that prevents rate-limit errors before they happen.',
+    repository: 'https://github.com/utensils/strainer',
+    techStack: ['Rust', 'CLI', 'AI/LLM'],
+  },
+  {
+    name: 'pasta',
+    tagline: 'Clipboard to keystrokes',
+    description:
+      "A cross-platform tray app that converts clipboard content into simulated input for apps that don't support paste.",
+    repository: 'https://github.com/utensils/pasta',
+    techStack: ['Rust', 'Tauri', 'Cross-platform'],
+  },
+  {
+    name: 'Docker Darling',
+    tagline: 'macOS runtime in a container',
+    description:
+      'An experimental Docker container running Darling to execute macOS binaries on Linux.',
+    repository: 'https://github.com/utensils/docker-darling',
+    techStack: ['Docker', 'Darling', 'macOS'],
+  },
+];

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -22,6 +22,7 @@ interface Props {
   updatedDate?: Date;
   tags?: string[];
   noindex?: boolean;
+  additionalSchema?: Record<string, unknown>[];
 }
 
 const {
@@ -33,6 +34,7 @@ const {
   updatedDate,
   tags = [],
   noindex = false,
+  additionalSchema = [],
 } = Astro.props;
 const siteTitle = title === 'Home' ? 'James Brink — SRE/DevOps Engineer' : `${title} - James Brink`;
 
@@ -67,6 +69,7 @@ const websiteSchema = {
 };
 
 const graph: Record<string, unknown>[] = [personSchema, websiteSchema];
+graph.push(...additionalSchema);
 
 if (type === 'article' && publishDate) {
   graph.push({

--- a/src/layouts/ProjectLayout.astro
+++ b/src/layouts/ProjectLayout.astro
@@ -1,0 +1,289 @@
+---
+import type { CollectionEntry } from 'astro:content';
+import BaseLayout from './BaseLayout.astro';
+import Container from '../components/Container.astro';
+import Button from '../components/Button.astro';
+import type { GitHubProjectStats } from '../lib/github';
+
+interface Props {
+  slug: string;
+  project: CollectionEntry<'projects'>['data'];
+  stats: GitHubProjectStats | null;
+}
+
+const { slug, project, stats } = Astro.props;
+const projectURL = new URL(`/projects/${slug}/`, Astro.site).toString();
+const primaryLink = project.links[0];
+const githubLink = project.links.find((link) => link.url === project.repository);
+
+const projectSchema = {
+  '@type': 'SoftwareSourceCode',
+  '@id': `${projectURL}#software`,
+  name: project.title,
+  description: project.description,
+  url: projectURL,
+  codeRepository: project.repository,
+  programmingLanguage: project.language,
+  license: project.license,
+  keywords: project.keywords.join(', '),
+  dateModified: project.updatedDate.toISOString(),
+  author: { '@id': new URL('/#person', Astro.site).toString() },
+};
+
+const breadcrumbSchema = {
+  '@type': 'BreadcrumbList',
+  '@id': `${projectURL}#breadcrumb`,
+  itemListElement: [
+    {
+      '@type': 'ListItem',
+      position: 1,
+      name: 'Projects',
+      item: new URL('/projects/', Astro.site).toString(),
+    },
+    { '@type': 'ListItem', position: 2, name: project.title, item: projectURL },
+  ],
+};
+---
+
+<BaseLayout
+  title={project.title}
+  description={project.description}
+  image={`/projects/og/${slug}.png`}
+  additionalSchema={[projectSchema, breadcrumbSchema]}
+>
+  <Container class="mt-12 sm:mt-20 lg:mt-28">
+    <nav aria-label="Breadcrumb" class="text-muted font-mono text-xs">
+      <a href="/projects/" class="hover:text-link transition">Projects</a>
+      <span class="text-faint mx-2" aria-hidden="true">/</span>
+      <span aria-current="page">{project.title}</span>
+    </nav>
+
+    <header class="mt-10 max-w-4xl">
+      <h1 class="text-heading text-5xl font-bold tracking-tight sm:text-7xl">{project.title}</h1>
+      <p class="text-accent mt-4 text-xl italic sm:text-2xl">{project.tagline}</p>
+      <p class="text-body mt-7 max-w-2xl text-lg">{project.description}</p>
+
+      <div class="mt-8 flex flex-wrap gap-3">
+        <Button href={primaryLink.url} target="_blank" class="px-5 py-3">
+          {primaryLink.label}
+          <svg viewBox="0 0 20 20" fill="none" aria-hidden="true" class="h-4 w-4">
+            <path d="m7 5 5 5-5 5" stroke="currentColor" stroke-width="1.5"></path>
+          </svg>
+        </Button>
+        {
+          githubLink && githubLink.url !== primaryLink.url && (
+            <Button variant="secondary" href={githubLink.url} target="_blank" class="px-5 py-3">
+              View on GitHub
+              <svg viewBox="0 0 20 20" fill="none" aria-hidden="true" class="h-4 w-4">
+                <path
+                  d="M11 4h5v5M9 11l7-7M16 11v4a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V5a1 1 0 0 1 1-1h4"
+                  stroke="currentColor"
+                  stroke-width="1.4"
+                />
+              </svg>
+            </Button>
+          )
+        }
+      </div>
+
+      <dl
+        class="border-hairline mt-10 grid max-w-3xl grid-cols-2 gap-x-6 gap-y-5 border-y py-6 sm:grid-cols-4"
+      >
+        <div>
+          <dt class="text-muted font-mono text-xs tracking-wide uppercase">Language</dt>
+          <dd class="text-heading mt-1 text-lg font-semibold">{project.language}</dd>
+        </div>
+        <div>
+          <dt class="text-muted font-mono text-xs tracking-wide uppercase">License</dt>
+          <dd class="text-heading mt-1 text-lg font-semibold">{project.license}</dd>
+        </div>
+        <div>
+          <dt class="text-muted font-mono text-xs tracking-wide uppercase">Stars</dt>
+          <dd class="text-heading mt-1 text-lg font-semibold">{stats?.stars ?? '—'}</dd>
+        </div>
+        <div>
+          <dt class="text-muted font-mono text-xs tracking-wide uppercase">Forks</dt>
+          <dd class="text-heading mt-1 text-lg font-semibold">{stats?.forks ?? '—'}</dd>
+        </div>
+      </dl>
+    </header>
+  </Container>
+
+  <div class="border-hairline bg-sunken/45 mt-20 border-y sm:mt-28">
+    <Container class="py-16 sm:py-24">
+      <section aria-labelledby="problem-heading" class="grid gap-12 lg:grid-cols-2 lg:gap-20">
+        <div>
+          <h2
+            id="problem-heading"
+            class="text-heading text-3xl font-bold tracking-tight sm:text-4xl"
+          >
+            What it fixes
+          </h2>
+          <p class="text-body mt-5 text-base">{project.problem.body}</p>
+          <div class="text-muted mt-5 text-sm"><slot /></div>
+        </div>
+        <ul class="border-hairline text-body space-y-4 border-l pl-6 font-mono text-sm">
+          {
+            project.problem.pains.map((pain) => (
+              <li class="flex gap-3">
+                <span class="text-emission" aria-hidden="true">
+                  ×
+                </span>
+                {pain}
+              </li>
+            ))
+          }
+        </ul>
+      </section>
+    </Container>
+  </div>
+
+  <Container>
+    <section aria-labelledby="features-heading" class="py-20 sm:py-28">
+      <h2 id="features-heading" class="text-heading text-3xl font-bold tracking-tight sm:text-4xl">
+        What it actually does
+      </h2>
+      <p class="text-body mt-3 max-w-2xl">
+        A useful product surface, not another README wearing a blazer.
+      </p>
+      <div class="mt-10 grid gap-x-14 md:grid-cols-2">
+        {
+          project.features.map((feature, index) => (
+            <article class="border-hairline grid grid-cols-[2.5rem_1fr] gap-3 border-b py-6">
+              <span class="text-accent font-mono text-sm">
+                {String(index + 1).padStart(2, '0')}
+              </span>
+              <div>
+                <h3 class="text-heading text-lg font-semibold">{feature.title}</h3>
+                <p class="text-body mt-1 text-sm">{feature.description}</p>
+              </div>
+            </article>
+          ))
+        }
+      </div>
+    </section>
+
+    <section aria-labelledby="quickstart-heading" class="border-hairline border-t py-20 sm:py-28">
+      <h2
+        id="quickstart-heading"
+        class="text-heading text-3xl font-bold tracking-tight sm:text-4xl"
+      >
+        Pick your poison
+      </h2>
+      <p class="text-body mt-3">Run it the way that annoys you least.</p>
+      <div
+        class:list={[
+          'mt-9 grid gap-4',
+          project.quickStarts.length === 2 && 'lg:grid-cols-2',
+          project.quickStarts.length >= 3 && 'lg:grid-cols-3',
+        ]}
+      >
+        {
+          project.quickStarts.map((quickStart) => (
+            <div class="border-hairline bg-code overflow-hidden rounded-xl border">
+              <div class="border-hairline text-muted border-b px-4 py-3 font-mono text-xs">
+                {quickStart.label}
+              </div>
+              <pre class="text-code-text overflow-x-auto p-4 text-sm leading-6">
+                <code>{quickStart.code}</code>
+              </pre>
+            </div>
+          ))
+        }
+      </div>
+    </section>
+
+    <section aria-labelledby="integrations-heading" class="border-hairline border-t py-20 sm:py-24">
+      <h2
+        id="integrations-heading"
+        class="text-heading text-3xl font-bold tracking-tight sm:text-4xl"
+      >
+        Plays well with the tools already causing trouble
+      </h2>
+      <ul
+        class="text-body mt-9 grid grid-cols-2 gap-x-6 gap-y-4 font-mono text-sm sm:grid-cols-3 lg:grid-cols-4"
+      >
+        {
+          project.integrations.map((integration) => (
+            <li class="border-hairline flex items-center gap-3 border-b pb-4">
+              <span
+                class="bg-emission h-2 w-2 rounded-full shadow-[var(--shadow-glow)]"
+                aria-hidden="true"
+              />
+              {integration}
+            </li>
+          ))
+        }
+      </ul>
+    </section>
+
+    <section aria-labelledby="architecture-heading" class="border-hairline border-t py-20 sm:py-28">
+      <h2
+        id="architecture-heading"
+        class="text-heading text-3xl font-bold tracking-tight sm:text-4xl"
+      >
+        Under the hood
+      </h2>
+      <p class="text-body mt-3">
+        Simple enough to explain without a thirty-slide architecture deck.
+      </p>
+      <ol class="mt-10 grid gap-4 lg:grid-cols-4">
+        {
+          project.architecture.map((step, index) => (
+            <li class="border-hairline relative rounded-xl border p-5">
+              <span class="text-accent font-mono text-xs">0{index + 1}</span>
+              <h3 class="text-heading mt-3 font-semibold">{step.title}</h3>
+              <p class="text-body mt-2 text-sm">{step.description}</p>
+              {index < project.architecture.length - 1 && (
+                <span
+                  class="text-emission absolute top-1/2 -right-3 hidden lg:block"
+                  aria-hidden="true"
+                >
+                  →
+                </span>
+              )}
+            </li>
+          ))
+        }
+      </ol>
+    </section>
+  </Container>
+
+  <div class="border-hairline bg-sunken/45 border-t">
+    <Container class="py-16 text-center sm:py-20">
+      <h2 class="text-heading text-3xl font-bold tracking-tight sm:text-4xl">
+        {project.closing.title}
+      </h2>
+      <p class="text-body mx-auto mt-3 max-w-xl">{project.closing.body}</p>
+      <div class="mt-7 flex flex-wrap justify-center gap-3">
+        {
+          project.links.map((link, index) => (
+            <Button
+              variant={index === 0 ? 'primary' : 'secondary'}
+              href={link.url}
+              target="_blank"
+              class="px-5 py-3"
+            >
+              {link.label}
+            </Button>
+          ))
+        }
+      </div>
+      {
+        stats?.latestRelease && (
+          <p class="text-muted mt-6 font-mono text-xs">
+            Latest release:{' '}
+            <a
+              href={stats.latestReleaseUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              class="text-link"
+            >
+              {stats.latestRelease}
+            </a>
+          </p>
+        )
+      }
+    </Container>
+  </div>
+</BaseLayout>

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -1,0 +1,45 @@
+export interface GitHubProjectStats {
+  stars: number;
+  forks: number;
+  latestRelease?: string;
+  latestReleaseUrl?: string;
+}
+
+export function getRepoFromUrl(url: string): string | null {
+  const match = url.match(/github\.com\/([^/]+\/[^/]+)/);
+  return match ? match[1].replace(/\.git$/, '') : null;
+}
+
+export async function fetchGitHubProjectStats(
+  repositoryUrl: string
+): Promise<GitHubProjectStats | null> {
+  const repo = getRepoFromUrl(repositoryUrl);
+  if (!repo) return null;
+
+  try {
+    const headers = {
+      Accept: 'application/vnd.github.v3+json',
+      'User-Agent': 'jamesbrink-website',
+    };
+    const [repositoryResponse, releaseResponse] = await Promise.all([
+      fetch(`https://api.github.com/repos/${repo}`, { headers }),
+      fetch(`https://api.github.com/repos/${repo}/releases/latest`, { headers }),
+    ]);
+
+    if (!repositoryResponse.ok) return null;
+
+    const repository = await repositoryResponse.json();
+    const release = releaseResponse.ok ? await releaseResponse.json() : null;
+
+    return {
+      stars: repository.stargazers_count,
+      forks: repository.forks_count,
+      ...(release?.tag_name && {
+        latestRelease: release.tag_name,
+        latestReleaseUrl: release.html_url,
+      }),
+    };
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/og.ts
+++ b/src/lib/og.ts
@@ -21,6 +21,12 @@ interface OgPost {
   tags: string[];
 }
 
+interface OgProject {
+  title: string;
+  tagline: string;
+  techStack: string[];
+}
+
 // satori element helper (object syntax — no JSX in .ts)
 function el(
   type: string,
@@ -113,5 +119,82 @@ export async function renderOgImage({ title, date, tags }: OgPost): Promise<Arra
 
   const png = await sharp(Buffer.from(svg)).png().toBuffer();
   // Slice out of Node's Buffer pool so Response gets exactly the PNG bytes.
+  return png.buffer.slice(png.byteOffset, png.byteOffset + png.byteLength) as ArrayBuffer;
+}
+
+export async function renderProjectOgImage({
+  title,
+  tagline,
+  techStack,
+}: OgProject): Promise<ArrayBuffer> {
+  const [mono400, mono600] = await fonts;
+  const svg = await satori(
+    el(
+      'div',
+      {
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'space-between',
+        padding: '68px 80px',
+        backgroundColor: '#0a0506',
+        backgroundImage:
+          'radial-gradient(circle at 86% 18%, rgba(255, 61, 99, 0.3), rgba(10, 5, 6, 0) 52%)',
+        border: '2px solid rgba(255, 61, 99, 0.35)',
+        color: '#f5f1ec',
+        fontFamily: 'IBM Plex Mono',
+      },
+      [
+        el('div', { display: 'flex', flexDirection: 'column', maxWidth: '920px' }, [
+          el(
+            'div',
+            {
+              fontSize: '24px',
+              fontWeight: 600,
+              letterSpacing: '0.18em',
+              textTransform: 'uppercase',
+              color: '#ff3d63',
+            },
+            'James Brink · Projects'
+          ),
+          el(
+            'div',
+            { marginTop: '38px', fontSize: '76px', fontWeight: 600, lineHeight: 1.05 },
+            title
+          ),
+          el(
+            'div',
+            { marginTop: '28px', fontSize: '30px', lineHeight: 1.35, color: '#c9bfb6' },
+            tagline
+          ),
+        ]),
+        el(
+          'div',
+          {
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            fontSize: '22px',
+            color: '#a89f96',
+          },
+          [
+            el('div', { display: 'flex' }, techStack.slice(0, 4).join('  ·  ')),
+            el('div', { display: 'flex' }, 'jamesbrink.online'),
+          ]
+        ),
+      ]
+    ),
+    {
+      width: 1200,
+      height: 630,
+      fonts: [
+        { name: 'IBM Plex Mono', data: mono400, weight: 400, style: 'normal' },
+        { name: 'IBM Plex Mono', data: mono600, weight: 600, style: 'normal' },
+      ],
+    }
+  );
+
+  const png = await sharp(Buffer.from(svg)).png().toBuffer();
   return png.buffer.slice(png.byteOffset, png.byteOffset + png.byteLength) as ArrayBuffer;
 }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -144,20 +144,28 @@ const socialLinks = [
       </p>
 
       <!-- Selected wins — quantified proof to balance the self-deprecation -->
-      <dl class="border-hairline mt-8 grid max-w-xl grid-cols-3 gap-4 border-y py-6">
-        <div>
-          <dt class="text-muted font-mono text-xs tracking-wide uppercase">Cloud cost cut</dt>
-          <dd class="text-heading mt-1 text-3xl font-bold tracking-tight">45%</dd>
+      <dl
+        class="border-hairline mt-8 grid max-w-xl grid-cols-3 items-start gap-3 border-y py-6 sm:gap-4"
+      >
+        <div class="grid min-w-0 grid-rows-[3rem_auto] sm:block">
+          <dt class="text-muted font-mono text-xs leading-5 tracking-wide uppercase">
+            Cloud cost cut
+          </dt>
+          <dd class="text-heading mt-1 self-start text-3xl font-bold tracking-tight">45%</dd>
         </div>
-        <div>
-          <dt class="text-muted font-mono text-xs tracking-wide uppercase">OSS projects</dt>
-          <dd class="text-heading mt-1 text-3xl font-bold tracking-tight">
+        <div class="grid min-w-0 grid-rows-[3rem_auto] sm:block">
+          <dt class="text-muted font-mono text-xs leading-5 tracking-wide uppercase">
+            OSS projects
+          </dt>
+          <dd class="text-heading mt-1 self-start text-3xl font-bold tracking-tight">
             20<span class="text-muted text-lg font-normal">+</span>
           </dd>
         </div>
-        <div>
-          <dt class="text-muted font-mono text-xs tracking-wide uppercase">In production</dt>
-          <dd class="text-heading mt-1 text-3xl font-bold tracking-tight">
+        <div class="grid min-w-0 grid-rows-[3rem_auto] sm:block">
+          <dt class="text-muted font-mono text-xs leading-5 tracking-wide uppercase">
+            In production
+          </dt>
+          <dd class="text-heading mt-1 self-start text-3xl font-bold tracking-tight">
             20<span class="text-muted text-lg font-normal">yrs</span>
           </dd>
         </div>

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -1,314 +1,83 @@
 ---
+import { getCollection } from 'astro:content';
 import SimpleLayout from '../layouts/SimpleLayout.astro';
-import ProjectCard from '../components/ProjectCard.astro';
-import type { Project } from '../components/ProjectCard.astro';
+import ProjectCard, { type ProjectSummary } from '../components/ProjectCard.astro';
+import { otherProjects } from '../data/projects';
+import { fetchGitHubProjectStats } from '../lib/github';
 
-// Helper to extract owner/repo from GitHub URL
-function getRepoFromUrl(url: string): string | null {
-  const match = url.match(/github\.com\/([^/]+\/[^/]+)/);
-  return match ? match[1] : null;
+async function enrich(project: ProjectSummary): Promise<ProjectSummary> {
+  const stats = await fetchGitHubProjectStats(project.repository);
+  return stats ? { ...project, ...stats } : project;
 }
 
-// Fetch GitHub stats for a repo
-async function fetchGitHubStats(repo: string): Promise<{ stars: number; forks: number } | null> {
-  try {
-    const response = await fetch(`https://api.github.com/repos/${repo}`, {
-      headers: {
-        Accept: 'application/vnd.github.v3+json',
-        'User-Agent': 'jamesbrink-website',
-      },
-    });
-    if (!response.ok) return null;
-    const data = await response.json();
-    return {
-      stars: data.stargazers_count,
-      forks: data.forks_count,
-    };
-  } catch {
-    return null;
-  }
-}
+const projectEntries = (await getCollection('projects')).sort(
+  (a, b) => a.data.featuredOrder - b.data.featuredOrder
+);
 
-// Base project data (without live stats)
-const baseFeatureProjects: Omit<Project, 'stars' | 'forks'>[] = [
-  {
-    name: 'MCP NixOS',
-    tagline: 'AI meets NixOS',
-    description:
-      'A Model Context Protocol server that enables AI assistants like Claude to query NixOS packages, options, and Home Manager configurations. Makes AI-assisted NixOS development practical and precise.',
-    href: 'https://github.com/utensils/mcp-nixos',
-    techStack: ['Python', 'MCP', 'NixOS', 'AI/LLM'],
-    featured: true,
-  },
-  {
-    name: 'Envisaged',
-    tagline: 'Visualize your git history',
-    description:
-      'Docker-wrapped Gource visualizations that generate stunning videos of repository history. Used by hundreds of developers to create visual retrospectives and project demos without manual setup.',
-    href: 'https://github.com/utensils/Envisaged',
-    techStack: ['Docker', 'Gource', 'FFmpeg', 'Shell'],
-    featured: true,
-  },
-  {
-    name: 'nxv',
-    tagline: 'Fast Nix package version lookup',
-    description:
-      'A blazingly fast CLI tool for finding any version of any Nix package across channels and history. Essential for pinning specific package versions in Nix configurations.',
-    href: 'https://github.com/utensils/nxv',
-    techStack: ['Rust', 'NixOS'],
-    featured: true,
-  },
-  {
-    name: 'ComfyUI Nix',
-    tagline: 'Reproducible AI image generation',
-    description:
-      'A Nix flake for running ComfyUI with a curated selection of custom nodes. Provides reproducible, declarative AI image generation environments for creative workflows.',
-    href: 'https://github.com/utensils/comfyui-nix',
-    techStack: ['Nix', 'Python', 'ComfyUI', 'AI/ML'],
-    featured: true,
-  },
-  {
-    name: 'Claudette',
-    tagline: "Claude Code's better half",
-    description:
-      'A Tauri companion app for Claude Code that manages git worktrees, remote workspaces, and multi-agent orchestration — the missing better half for anyone living in Claude Code all day.',
-    href: 'https://github.com/utensils/claudette',
-    techStack: ['Rust', 'Tauri', 'Claude Code', 'MCP'],
-    featured: true,
-  },
-  {
-    name: 'mold',
-    tagline: 'Local diffusion image generation',
-    description:
-      'A fast Rust CLI for local AI image generation — FLUX, SD 1.5, SDXL, and Z-Image models running on your own GPU via Candle. No cloud, no API keys, no rate limits.',
-    href: 'https://github.com/utensils/mold',
-    techStack: ['Rust', 'Candle', 'CUDA', 'Diffusion'],
-    featured: true,
-  },
-];
-
-const baseProjects: Omit<Project, 'stars' | 'forks'>[] = [
-  {
-    name: 'Docker OpenGL',
-    tagline: 'Software rendering in containers',
-    description:
-      'Mesa 3D OpenGL software rendering for Docker containers. Enables GPU-less rendering for CI/CD pipelines, headless servers, and testing environments.',
-    href: 'https://github.com/utensils/docker-opengl',
-    techStack: ['Docker', 'Mesa3D', 'OpenGL'],
-  },
-  {
-    name: 'Essex',
-    tagline: 'Docker project scaffolding',
-    description:
-      'A Rust-based CLI tool for generating Docker project templates. Standardizes container project structure with best practices baked in.',
-    href: 'https://github.com/utensils/essex',
-    techStack: ['Rust', 'Docker', 'CLI'],
-  },
-  {
-    name: 'MCP Coroot',
-    tagline: 'AI-powered observability queries',
-    description:
-      'Model Context Protocol server for the Coroot observability platform. Enables AI assistants to query infrastructure metrics and application performance data.',
-    href: 'https://github.com/jamesbrink/mcp-coroot',
-    techStack: ['TypeScript', 'MCP', 'Coroot'],
-  },
-  {
-    name: 'MCP Deadmansnitch',
-    tagline: 'AI monitoring integration',
-    description:
-      "MCP server for Dead Man's Snitch monitoring service. Allows AI assistants to check cron job health and monitoring status.",
-    href: 'https://github.com/jamesbrink/mcp-deadmansnitch',
-    techStack: ['TypeScript', 'MCP', 'Monitoring'],
-  },
-  {
-    name: 'brinkOS',
-    tagline: 'Linux for engineers',
-    description:
-      'A custom Arch-based Linux distribution tailored for software engineers and power users. Includes a curated set of development tools, thoughtful defaults, and automated installation.',
-    href: 'https://github.com/brinkOS/brinkOS',
-    techStack: ['Arch Linux', 'Shell', 'Systemd'],
-  },
-  {
-    name: 'Arch Linux AUR',
-    tagline: 'Package maintainer',
-    description:
-      'Maintainer of several packages in the Arch User Repository. Contributing to the Arch ecosystem by packaging and maintaining software for the community.',
-    href: 'https://github.com/jamesbrink/arch-aur',
-    techStack: ['Arch Linux', 'PKGBUILD', 'Shell'],
-  },
-  {
-    name: 'koban',
-    tagline: 'Invoice Ninja from the terminal',
-    description:
-      'A scriptable Rust CLI and client library for Invoice Ninja — clients, invoices, payments, and reports from the terminal, designed for humans and AI agents alike.',
-    href: 'https://github.com/jamesbrink/koban',
-    techStack: ['Rust', 'CLI', 'Nix', 'REST API'],
-  },
-  {
-    name: 'claudex',
-    tagline: 'Search your Claude Code sessions',
-    description:
-      'A Rust CLI to query, search, and analyze Claude Code session history, backed by SQLite full-text search. Observability for your AI pair-programming.',
-    href: 'https://github.com/utensils/claudex',
-    techStack: ['Rust', 'SQLite', 'FTS5', 'CLI'],
-  },
-  {
-    name: 'aethon',
-    tagline: 'Pi with a face',
-    description:
-      'A Tauri desktop shell that embeds the pi coding agent and renders its output as live, interactive UI via the A2UI protocol — a canvas the agent populates, not a fixed IDE layout.',
-    href: 'https://github.com/utensils/aethon',
-    techStack: ['Tauri', 'React', 'A2UI', 'Rust'],
-  },
-  {
-    name: 'yeet',
-    tagline: 'Brutally rude AI commit messages',
-    description:
-      "A lazy developer's git tool that uses a local Ollama model to write technically accurate — but hilariously offensive — conventional commit messages, then pushes them for you.",
-    href: 'https://github.com/utensils/yeet',
-    techStack: ['Bash', 'Ollama', 'Local LLM'],
-  },
-  {
-    name: 'why',
-    tagline: 'Offline error explanations',
-    description:
-      'A CLI that explains programming errors using a locally-embedded LLM. No API keys. No internet. No patience required.',
-    href: 'https://github.com/jamesbrink/why',
-    techStack: ['Rust', 'LLM', 'Offline', 'Nix'],
-  },
-  {
-    name: 'burnrate',
-    tagline: 'AI spend at a glance',
-    description:
-      'A menu-bar usage monitor for Claude Code, Codex, OpenRouter, Runpod, and AWS — quotas, credits, spend, and subscription limits without leaving your status bar.',
-    href: 'https://github.com/jamesbrink/burnrate',
-    techStack: ['Rust', 'Tauri', 'React'],
-  },
-  {
-    name: 'strainer',
-    tagline: 'Rate limiting for AI APIs',
-    description:
-      'Process-level rate limiting and spend management for AI API consumers — prevents rate-limit errors by controlling how fast processes execute.',
-    href: 'https://github.com/utensils/strainer',
-    techStack: ['Rust', 'CLI', 'AI/LLM'],
-  },
-  {
-    name: 'pasta',
-    tagline: 'Clipboard to keystrokes',
-    description:
-      "A cross-platform system-tray app that converts clipboard content into simulated keyboard input, bridging apps that don't support a direct paste.",
-    href: 'https://github.com/utensils/pasta',
-    techStack: ['Rust', 'Tauri', 'Cross-platform'],
-  },
-  {
-    name: 'Docker Darling',
-    tagline: 'macOS runtime in a container',
-    description:
-      'An experimental Docker container running Darling — the Darwin/macOS translation layer — to execute macOS binaries on Linux.',
-    href: 'https://github.com/utensils/docker-darling',
-    techStack: ['Docker', 'Darling', 'macOS'],
-  },
-];
-
-// Fetch GitHub stats for all projects at build time
-async function enrichWithGitHubStats<T extends { href: string }>(
-  projects: T[]
-): Promise<(T & { stars?: number; forks?: number })[]> {
-  const enrichedProjects = await Promise.all(
-    projects.map(async (project) => {
-      const repo = getRepoFromUrl(project.href);
-      if (!repo) return project;
-
-      const stats = await fetchGitHubStats(repo);
-      if (!stats) return project;
-
-      return {
-        ...project,
-        stars: stats.stars,
-        forks: stats.forks,
-      };
+const featuredProjects = await Promise.all(
+  projectEntries.map((entry) =>
+    enrich({
+      slug: entry.id,
+      name: entry.data.title,
+      tagline: entry.data.tagline,
+      description: entry.data.description,
+      repository: entry.data.repository,
+      techStack: entry.data.techStack,
+      featured: true,
     })
-  );
-  return enrichedProjects;
-}
+  )
+);
 
-// Enrich projects with live GitHub stats
-const featuredProjects: Project[] = await enrichWithGitHubStats(baseFeatureProjects);
-const projects: Project[] = await enrichWithGitHubStats(baseProjects);
+const projects = await Promise.all(otherProjects.map(enrich));
 ---
 
 <SimpleLayout
   title="Projects"
   intro="Open source tools and experiments that solve real problems. These projects reflect my interests in infrastructure automation, AI tooling, and developer experience."
+  description="Open-source NixOS, AI infrastructure, developer tooling, and automation projects created and maintained by James Brink."
 >
   <div class="space-y-20">
-    <!-- Featured Projects -->
     <section>
       <h2 class="text-heading text-2xl font-bold tracking-tight">Featured Projects</h2>
       <p class="text-body mt-2 text-sm">
-        Projects with significant community adoption or technical impact
+        The projects with enough scars to deserve the full story.
       </p>
       <div class="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-2">
         {featuredProjects.map((project) => <ProjectCard project={project} featured />)}
       </div>
     </section>
 
-    <!-- All Projects -->
     <section>
       <h2 class="text-heading text-2xl font-bold tracking-tight">More Projects</h2>
-      <p class="text-body mt-2 text-sm">Tools, utilities, and experiments from across my GitHub</p>
+      <p class="text-body mt-2 text-sm">Tools, utilities, and experiments from across my GitHub.</p>
       <div class="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
         {projects.map((project) => <ProjectCard project={project} />)}
       </div>
     </section>
 
-    <!-- GitHub CTA -->
-    <section class="border-hairline rounded-2xl border p-8">
-      <div class="flex flex-col items-center text-center">
-        <svg class="text-muted h-12 w-12" fill="currentColor" viewBox="0 0 24 24">
-          <path
-            fill-rule="evenodd"
-            clip-rule="evenodd"
-            d="M12 2C6.475 2 2 6.588 2 12.253c0 4.537 2.862 8.369 6.838 9.727.5.09.687-.218.687-.487 0-.243-.013-1.05-.013-1.91C7 20.059 6.35 18.957 6.15 18.38c-.113-.295-.6-1.205-1.025-1.448-.35-.192-.85-.667-.013-.68.788-.012 1.35.744 1.538 1.051.9 1.551 2.338 1.116 2.912.846.088-.666.35-1.115.638-1.371-2.225-.256-4.55-1.14-4.55-5.062 0-1.115.387-2.038 1.025-2.756-.1-.256-.45-1.307.1-2.717 0 0 .837-.269 2.75 1.051.8-.23 1.65-.346 2.5-.346.85 0 1.7.115 2.5.346 1.912-1.333 2.75-1.05 2.75-1.05.55 1.409.2 2.46.1 2.716.637.718 1.025 1.628 1.025 2.756 0 3.934-2.337 4.806-4.562 5.062.362.32.675.936.675 1.897 0 1.371-.013 2.473-.013 2.82 0 .268.188.589.688.486a10.039 10.039 0 0 0 4.932-3.74A10.447 10.447 0 0 0 22 12.253C22 6.588 17.525 2 12 2Z"
-          ></path>
-        </svg>
-        <h3 class="text-heading mt-4 text-lg font-semibold">Explore more on GitHub</h3>
-        <p class="text-body mt-2 text-sm">
-          These are just the highlights. Check out my full profile for more projects, contributions,
-          and experiments.
-        </p>
-        <div class="mt-6 flex gap-4">
-          <a
-            href="https://github.com/jamesbrink"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="bg-emission text-on-solid inline-flex items-center gap-2 rounded-full px-4 py-2 text-sm font-medium shadow-[var(--shadow-glow)] transition"
-          >
-            <svg class="h-5 w-5" fill="currentColor" viewBox="0 0 24 24">
-              <path
-                fill-rule="evenodd"
-                clip-rule="evenodd"
-                d="M12 2C6.475 2 2 6.588 2 12.253c0 4.537 2.862 8.369 6.838 9.727.5.09.687-.218.687-.487 0-.243-.013-1.05-.013-1.91C7 20.059 6.35 18.957 6.15 18.38c-.113-.295-.6-1.205-1.025-1.448-.35-.192-.85-.667-.013-.68.788-.012 1.35.744 1.538 1.051.9 1.551 2.338 1.116 2.912.846.088-.666.35-1.115.638-1.371-2.225-.256-4.55-1.14-4.55-5.062 0-1.115.387-2.038 1.025-2.756-.1-.256-.45-1.307.1-2.717 0 0 .837-.269 2.75 1.051.8-.23 1.65-.346 2.5-.346.85 0 1.7.115 2.5.346 1.912-1.333 2.75-1.05 2.75-1.05.55 1.409.2 2.46.1 2.716.637.718 1.025 1.628 1.025 2.756 0 3.934-2.337 4.806-4.562 5.062.362.32.675.936.675 1.897 0 1.371-.013 2.473-.013 2.82 0 .268.188.589.688.486a10.039 10.039 0 0 0 4.932-3.74A10.447 10.447 0 0 0 22 12.253C22 6.588 17.525 2 12 2Z"
-              ></path>
-            </svg>
-            @jamesbrink
-          </a>
-          <a
-            href="https://github.com/utensils"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="bg-pill text-body inline-flex items-center gap-2 rounded-full px-4 py-2 text-sm font-medium transition"
-          >
-            <svg class="h-5 w-5" fill="currentColor" viewBox="0 0 24 24">
-              <path
-                fill-rule="evenodd"
-                clip-rule="evenodd"
-                d="M12 2C6.475 2 2 6.588 2 12.253c0 4.537 2.862 8.369 6.838 9.727.5.09.687-.218.687-.487 0-.243-.013-1.05-.013-1.91C7 20.059 6.35 18.957 6.15 18.38c-.113-.295-.6-1.205-1.025-1.448-.35-.192-.85-.667-.013-.68.788-.012 1.35.744 1.538 1.051.9 1.551 2.338 1.116 2.912.846.088-.666.35-1.115.638-1.371-2.225-.256-4.55-1.14-4.55-5.062 0-1.115.387-2.038 1.025-2.756-.1-.256-.45-1.307.1-2.717 0 0 .837-.269 2.75 1.051.8-.23 1.65-.346 2.5-.346.85 0 1.7.115 2.5.346 1.912-1.333 2.75-1.05 2.75-1.05.55 1.409.2 2.46.1 2.716.637.718 1.025 1.628 1.025 2.756 0 3.934-2.337 4.806-4.562 5.062.362.32.675.936.675 1.897 0 1.371-.013 2.473-.013 2.82 0 .268.188.589.688.486a10.039 10.039 0 0 0 4.932-3.74A10.447 10.447 0 0 0 22 12.253C22 6.588 17.525 2 12 2Z"
-              ></path>
-            </svg>
-            @utensils
-          </a>
-        </div>
+    <section class="border-hairline rounded-2xl border p-8 text-center">
+      <h2 class="text-heading text-xl font-semibold">The rest of the workshop</h2>
+      <p class="text-body mx-auto mt-2 max-w-xl text-sm">
+        These are the highlights. The stranger experiments and unfinished crimes against software
+        live on GitHub.
+      </p>
+      <div class="mt-6 flex flex-wrap justify-center gap-3">
+        <a
+          href="https://github.com/jamesbrink"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="bg-emission text-on-solid rounded-md px-4 py-2 text-sm font-semibold"
+        >
+          @jamesbrink
+        </a>
+        <a
+          href="https://github.com/utensils"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="border-hairline text-body rounded-md border px-4 py-2 text-sm font-medium"
+        >
+          @utensils
+        </a>
       </div>
     </section>
   </div>

--- a/src/pages/projects/[slug].astro
+++ b/src/pages/projects/[slug].astro
@@ -1,0 +1,18 @@
+---
+import { getCollection, render } from 'astro:content';
+import ProjectLayout from '../../layouts/ProjectLayout.astro';
+import { fetchGitHubProjectStats } from '../../lib/github';
+
+export async function getStaticPaths() {
+  const projects = await getCollection('projects');
+  return projects.map((project) => ({ params: { slug: project.id }, props: { project } }));
+}
+
+const { project } = Astro.props;
+const { Content } = await render(project);
+const stats = await fetchGitHubProjectStats(project.data.repository);
+---
+
+<ProjectLayout slug={project.id} project={project.data} stats={stats}>
+  <Content />
+</ProjectLayout>

--- a/src/pages/projects/og/[slug].png.ts
+++ b/src/pages/projects/og/[slug].png.ts
@@ -1,0 +1,18 @@
+import type { APIRoute } from 'astro';
+import { getCollection } from 'astro:content';
+import { renderProjectOgImage } from '../../../lib/og';
+
+export async function getStaticPaths() {
+  const projects = await getCollection('projects');
+  return projects.map((project) => ({ params: { slug: project.id }, props: { project } }));
+}
+
+export const GET: APIRoute = async ({ props }) => {
+  const { project } = props;
+  const png = await renderProjectOgImage({
+    title: project.data.title,
+    tagline: project.data.tagline,
+    techStack: project.data.techStack,
+  });
+  return new Response(png, { headers: { 'Content-Type': 'image/png' } });
+};

--- a/tests/github.test.ts
+++ b/tests/github.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { fetchGitHubProjectStats, getRepoFromUrl } from '../src/lib/github';
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('GitHub project metadata', () => {
+  it('extracts owner and repository names', () => {
+    expect(getRepoFromUrl('https://github.com/utensils/nxv')).toBe('utensils/nxv');
+    expect(getRepoFromUrl('https://github.com/utensils/nxv.git')).toBe('utensils/nxv');
+    expect(getRepoFromUrl('https://example.com/utensils/nxv')).toBeNull();
+  });
+
+  it('returns repository metrics and the latest release', async () => {
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ stargazers_count: 133, forks_count: 1 }), { status: 200 })
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            tag_name: 'v0.4.4',
+            html_url: 'https://github.com/utensils/nxv/releases/tag/v0.4.4',
+          }),
+          { status: 200 }
+        )
+      );
+
+    await expect(fetchGitHubProjectStats('https://github.com/utensils/nxv')).resolves.toEqual({
+      stars: 133,
+      forks: 1,
+      latestRelease: 'v0.4.4',
+      latestReleaseUrl: 'https://github.com/utensils/nxv/releases/tag/v0.4.4',
+    });
+  });
+
+  it('keeps metrics when a repository has no release', async () => {
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ stargazers_count: 10, forks_count: 2 }), { status: 200 })
+      )
+      .mockResolvedValueOnce(new Response('', { status: 404 }));
+
+    await expect(fetchGitHubProjectStats('https://github.com/utensils/Envisaged')).resolves.toEqual(
+      {
+        stars: 10,
+        forks: 2,
+      }
+    );
+  });
+
+  it('falls back cleanly when GitHub is unavailable', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('offline'));
+    await expect(fetchGitHubProjectStats('https://github.com/utensils/nxv')).resolves.toBeNull();
+  });
+});

--- a/tests/project-content.test.ts
+++ b/tests/project-content.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import matter from 'gray-matter';
+import { compile } from '@mdx-js/mdx';
+
+const projectsDir = path.join(process.cwd(), 'src/content/projects');
+const files = fs.readdirSync(projectsDir).filter((file) => file.endsWith('.mdx'));
+const expectedProjects = [
+  'claudette.mdx',
+  'comfyui-nix.mdx',
+  'envisaged.mdx',
+  'mcp-nixos.mdx',
+  'mold.mdx',
+  'nxv.mdx',
+];
+
+describe('project landing-page content', () => {
+  it('defines exactly the six featured projects', () => {
+    expect(files.sort()).toEqual(expectedProjects);
+  });
+
+  it('uses unique ordering and SEO descriptions', () => {
+    const entries = files.map(
+      (file) => matter(fs.readFileSync(path.join(projectsDir, file), 'utf8')).data
+    );
+    expect(new Set(entries.map((entry) => entry.featuredOrder)).size).toBe(entries.length);
+    expect(new Set(entries.map((entry) => entry.description)).size).toBe(entries.length);
+    for (const entry of entries) {
+      expect(entry.description.length).toBeGreaterThanOrEqual(120);
+      expect(entry.description.length).toBeLessThanOrEqual(160);
+      expect(entry.repository).toMatch(/^https:\/\/github\.com\//);
+      expect(entry.features.length).toBeGreaterThanOrEqual(4);
+      expect(entry.quickStarts.length).toBeGreaterThanOrEqual(1);
+      expect(entry.architecture.length).toBeGreaterThanOrEqual(3);
+    }
+  });
+
+  for (const file of files) {
+    it(`${file} compiles as MDX`, async () => {
+      const source = fs.readFileSync(path.join(projectsDir, file), 'utf8');
+      const { content } = matter(source);
+      expect(content.trim()).not.toBe('');
+      await expect(compile(content, { format: 'mdx', development: false })).resolves.toBeTruthy();
+    });
+  }
+});

--- a/tests/visual-regression/project-pages.spec.ts
+++ b/tests/visual-regression/project-pages.spec.ts
@@ -1,0 +1,55 @@
+import { expect, test } from '@playwright/test';
+
+const projects = ['mcp-nixos', 'envisaged', 'nxv', 'comfyui-nix', 'claudette', 'mold'];
+
+test.describe('project landing pages', () => {
+  for (const slug of projects) {
+    test(`${slug} has complete search metadata and no horizontal overflow`, async ({ page }) => {
+      await page.goto(`/projects/${slug}/`);
+
+      await expect(page.locator('h1')).toBeVisible();
+      const description = await page.locator('meta[name="description"]').getAttribute('content');
+      expect(description?.length).toBeGreaterThanOrEqual(120);
+      await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
+        'href',
+        `https://jamesbrink.online/projects/${slug}/`
+      );
+      await expect(page.locator('meta[property="og:image"]')).toHaveAttribute(
+        'content',
+        `https://jamesbrink.online/projects/og/${slug}.png`
+      );
+
+      const schema = await page.locator('script[type="application/ld+json"]').textContent();
+      expect(schema).toContain('SoftwareSourceCode');
+      expect(schema).toContain('BreadcrumbList');
+      expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBe(
+        await page.evaluate(() => document.documentElement.clientWidth)
+      );
+    });
+  }
+
+  test('featured project cards lead to internal landing pages', async ({ page }) => {
+    await page.goto('/projects/');
+
+    const card = page.locator('article').filter({ hasText: 'MCP NixOS' }).first();
+    await expect(card.locator('a').first()).toHaveAttribute('href', '/projects/mcp-nixos/');
+    await expect(card.locator('a[aria-label*="GitHub"]')).toHaveAttribute(
+      'href',
+      'https://github.com/utensils/mcp-nixos'
+    );
+  });
+});
+
+test('homepage proof metrics align on mobile', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto('/');
+
+  const valueTops = await page
+    .locator('main dl')
+    .first()
+    .locator('div > dd')
+    .evaluateAll((values) => values.map((value) => Math.round(value.getBoundingClientRect().top)));
+
+  expect(new Set(valueTops).size).toBe(1);
+  expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBe(390);
+});


### PR DESCRIPTION
## Summary
- add six full product landing pages for MCP NixOS, Envisaged, nxv, ComfyUI Nix, Claudette, and mold
- add project-specific metadata, structured data, Open Graph images, sitemap dates, and live GitHub proof points
- route featured project cards internally while preserving direct GitHub links
- align the homepage proof metrics on mobile
- make Playwright portable and cover project SEO, links, overflow, and mobile metric alignment

## Verification
- `bun run test:run` (106 passed)
- `bun run lint:all`
- `bun run build` (35 pages)
- `bunx playwright test tests/visual-regression/project-pages.spec.ts` (16 passed)