### PR TITLE
fix(projects): repair mobile code block rendering

### DIFF
--- a/src/layouts/ProjectLayout.astro
+++ b/src/layouts/ProjectLayout.astro
@@ -180,13 +180,14 @@ const breadcrumbSchema = {
       >
         {
           project.quickStarts.map((quickStart) => (
-            <div class="border-hairline bg-code overflow-hidden rounded-xl border">
+            <div class="border-hairline bg-code min-w-0 overflow-hidden rounded-xl border">
               <div class="border-hairline text-muted border-b px-4 py-3 font-mono text-xs">
                 {quickStart.label}
               </div>
-              <pre class="text-code-text overflow-x-auto p-4 text-sm leading-6">
-                <code>{quickStart.code}</code>
-              </pre>
+              <pre
+                class="text-code-text m-0 max-w-full p-4 text-left text-sm leading-6 [overflow-wrap:anywhere] break-words whitespace-pre-wrap"
+                set:text={quickStart.code}
+              />
             </div>
           ))
         }

--- a/tests/visual-regression/project-pages.spec.ts
+++ b/tests/visual-regression/project-pages.spec.ts
@@ -25,6 +25,28 @@ test.describe('project landing pages', () => {
       expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBe(
         await page.evaluate(() => document.documentElement.clientWidth)
       );
+
+      await page.setViewportSize({ width: 390, height: 844 });
+      const codeBlocks = page.locator('#quickstart-heading + p + div pre');
+      await expect(codeBlocks.first()).toBeVisible();
+
+      for (const codeBlock of await codeBlocks.all()) {
+        const dimensions = await codeBlock.evaluate((element) => {
+          const preRect = element.getBoundingClientRect();
+          const range = document.createRange();
+          range.selectNodeContents(element);
+          const textRect = range.getClientRects()[0];
+
+          return {
+            clientWidth: element.clientWidth,
+            scrollWidth: element.scrollWidth,
+            textOffset: textRect ? Math.round(textRect.left - preRect.left) : -1,
+          };
+        });
+
+        expect(dimensions.scrollWidth).toBe(dimensions.clientWidth);
+        expect(dimensions.textOffset).toBe(16);
+      }
     });
   }
 


### PR DESCRIPTION
## Summary
- remove preserved template whitespace that shifted quick-start commands inside their cards
- wrap long commands within the code surface instead of clipping or requiring horizontal scrolling
- add mobile regression coverage for text alignment and internal code-block overflow across all six project pages

## Verification
- `bun run build`
- `bun run test:run` (106 passed)
- `bun run lint:all`
- `bunx playwright test tests/visual-regression/project-pages.spec.ts` (16 passed)
- Playwright QA at 390x1100 and 1440x900